### PR TITLE
Convert several components to React Hooks syntax

### DIFF
--- a/expo/src/AdminLogin.js
+++ b/expo/src/AdminLogin.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import axiosRequest from "Backend.js";
 
 import Error from "Error.js";
@@ -10,7 +10,6 @@ import "App.css";
 const InvalidErr = <Error text="Invalid login code!" />;
 
 export default function AdminLogin(props) {
-  const [loggedIn, setLoggedIn] = useState(false);
   const [error, setError] = useState("");
 
   const onLogin = accessCode => {
@@ -18,8 +17,6 @@ export default function AdminLogin(props) {
     let codeExists = accessCode !== undefined && accessCode !== "";
 
     if (codeExists) {
-      setLoggedIn(true);
-
       // Try to set logged in state for admin
       axiosRequest
         .post("api/login/admin", { access_code: accessCode })
@@ -27,21 +24,18 @@ export default function AdminLogin(props) {
           if (status === "Logged in as admin") {
             // Log in was successful
             // Clear errors on component
-            setLoggedIn(true);
             setError("");
 
             // Move to admin page
-            this.props.history.push({
+            props.history.push({
               pathname: "/admin"
             });
           } else {
             // Log in failed, show error
-            setLoggedIn(false);
             setError(InvalidErr);
           }
         });
     } else {
-      setLoggedIn(false);
       setError(InvalidErr);
     }
   };
@@ -49,8 +43,6 @@ export default function AdminLogin(props) {
   useEffect(() => {
     axiosRequest.get("api/whoami").then(credentials => {
       if (credentials !== undefined && credentials.user_type === "admin") {
-        setLoggedIn(true);
-
         props.history.push({
           pathname: "/admin"
         });

--- a/expo/src/AdminLogin.js
+++ b/expo/src/AdminLogin.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useEffect } from "react";
 import axiosRequest from "Backend.js";
 
 import Error from "Error.js";
@@ -9,35 +9,16 @@ import "App.css";
 
 const InvalidErr = <Error text="Invalid login code!" />;
 
-/* Admin login page content (see PRD) */
-class AdminLogin extends Component {
-  constructor() {
-    super();
-    this.state = {
-      loggedIn: false,
-      error: ""
-    };
-    this.onLogin = this.onLogin.bind(this);
-  }
+export default function AdminLogin(props) {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [error, setError] = useState("");
 
-  componentWillMount() {
-    // If already logged in, move directly to admin page
-    axiosRequest.get("api/whoami").then(credentials => {
-      if (credentials !== undefined && credentials.user_type === "admin") {
-        this.setState({ loggedIn: true, error: "" });
-        this.props.history.push({
-          pathname: "/admin"
-        });
-      }
-    });
-  }
-
-  onLogin(accessCode) {
+  const onLogin = accessCode => {
     // TODO Validate login code in place
     let codeExists = accessCode !== undefined && accessCode !== "";
 
     if (codeExists) {
-      this.setState({ logggedIn: true, error: "" });
+      setLoggedIn(true);
 
       // Try to set logged in state for admin
       axiosRequest
@@ -46,7 +27,8 @@ class AdminLogin extends Component {
           if (status === "Logged in as admin") {
             // Log in was successful
             // Clear errors on component
-            this.setState({ loggedIn: true, error: "" });
+            setLoggedIn(true);
+            setError("");
 
             // Move to admin page
             this.props.history.push({
@@ -54,25 +36,31 @@ class AdminLogin extends Component {
             });
           } else {
             // Log in failed, show error
-            this.setState({ loggedIn: false, error: InvalidErr });
+            setLoggedIn(false);
+            setError(InvalidErr);
           }
         });
     } else {
-      this.setState({ loggedIn: false, error: InvalidErr });
+      setLoggedIn(false);
+      setError(InvalidErr);
     }
-  }
+  };
 
-  render() {
-    return SiteWrapper(
-      <div className="AdminLogin">
-        <Login
-          title="Admin Login"
-          onLogin={this.onLogin}
-          error={this.state.error}
-        />
-      </div>
-    );
-  }
+  useEffect(() => {
+    axiosRequest.get("api/whoami").then(credentials => {
+      if (credentials !== undefined && credentials.user_type === "admin") {
+        setLoggedIn(true);
+
+        props.history.push({
+          pathname: "/admin"
+        });
+      }
+    });
+  }, []);
+
+  return SiteWrapper(
+    <div className="AdminLogin">
+      <Login title="Admin Login" onLogin={onLogin} error={error} />
+    </div>
+  );
 }
-
-export default AdminLogin;

--- a/expo/src/App.js
+++ b/expo/src/App.js
@@ -12,23 +12,23 @@ import Sponsor from "Sponsor.js";
 import SponsorLogin from "SponsorLogin.js";
 
 /* Routing control for app overall */
-const Routing = () => (
-  <Router basename="/">
-    {useCachedResponseData ? (
-      <div>
-        <Route exact path="/" component={Home} />
-        <Redirect to="/" />
-      </div>
-    ) : (
-      <div>
-        <Route exact path="/" component={Home} />
-        <Route path="/admin" component={Admin} />
-        <Route path="/sponsor" component={Sponsor} />
-        <Route path="/adminlogin" component={AdminLogin} />
-        <Route path="/sponsorlogin" component={SponsorLogin} />
-      </div>
-    )}
-  </Router>
-);
-
-export default Routing;
+export default function Routing() {
+  return (
+    <Router basename="/">
+      {useCachedResponseData ? (
+        <div>
+          <Route exact path="/" component={Home} />
+          <Redirect to="/" />
+        </div>
+      ) : (
+        <div>
+          <Route exact path="/" component={Home} />
+          <Route path="/admin" component={Admin} />
+          <Route path="/sponsor" component={Sponsor} />
+          <Route path="/adminlogin" component={AdminLogin} />
+          <Route path="/sponsorlogin" component={SponsorLogin} />
+        </div>
+      )}
+    </Router>
+  );
+}

--- a/expo/src/Error.js
+++ b/expo/src/Error.js
@@ -1,31 +1,23 @@
-import React, { Component } from "react";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
 library.add(faExclamationTriangle);
 
-class Error extends Component {
-  render() {
-    let font_awesome_icon =
-      this.props.icon === undefined ? faExclamationTriangle : this.props.icon;
-    let className =
-      this.props.iconstyle === undefined
-        ? "fa-exclamation-triangle"
-        : this.props.iconstyle;
-    return (
-      <div className="btn-group error-group" role="group">
-        <span className="error-icon">
-          <FontAwesomeIcon icon={font_awesome_icon} className={className} />
-        </span>
-        <span className="error-text">
-          {this.props.children === undefined
-            ? this.props.text
-            : this.props.children}
-        </span>
-      </div>
-    );
-  }
+export default function Error(props) {
+  let font_awesome_icon =
+    props.icon === undefined ? faExclamationTriangle : props.icon;
+  let className =
+    props.iconstyle === undefined ? "fa-exclamation-triangle" : props.iconstyle;
+  return (
+    <div className="btn-group error-group" role="group">
+      <span className="error-icon">
+        <FontAwesomeIcon icon={font_awesome_icon} className={className} />
+      </span>
+      <span className="error-text">
+        {props.children === undefined ? props.text : props.children}
+      </span>
+    </div>
+  );
 }
-
-export default Error;

--- a/expo/src/Home.js
+++ b/expo/src/Home.js
@@ -5,16 +5,14 @@ import SiteWrapper from "SiteWrapper.js";
 
 import "App.css";
 
-export default class Home extends React.Component {
-  render() {
-    return SiteWrapper(
-      <div class="Home">
-        <div class="row">
-          <div class="col">
-            <SearchandFilter origin="home" />
-          </div>
+export default function Home() {
+  return SiteWrapper(
+    <div class="Home">
+      <div class="row">
+        <div class="col">
+          <SearchandFilter origin="home" />
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/expo/src/Login.js
+++ b/expo/src/Login.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import Card from "components/Card.js";
 
 /*
@@ -9,50 +9,39 @@ Required this.props
   error - graphic or message to show on login failure
 */
 
-class Login extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      accessCode: ""
-    };
-  }
+export default function Login(props) {
+  const [accessCode, setAccessCode] = useState("");
 
-  render() {
-    return (
-      <div className="row">
-        <div className="col-md-8 offset-md-2">
-          <Card title={this.props.title}>
-            <div>
-              <form
-                onSubmit={e => {
-                  e.preventDefault();
-                  this.props.onLogin(this.state.accessCode);
-                }}
-              >
-                <div className="form-group">
-                  <label htmlFor="txtAccessCode">Access Code</label>
-                  <input
-                    type="text"
-                    id="txtAccessCode"
-                    className="form-control"
-                    onChange={event =>
-                      this.setState({ accessCode: event.target.value })
-                    }
-                  />
-                </div>
-                <button className="button button-primary" type="submit">
-                  Login
-                </button>
-                <br />
-                <br />
-                {this.props.error}
-              </form>
-            </div>
-          </Card>
-        </div>
+  return (
+    <div className="row">
+      <div className="col-md-8 offset-md-2">
+        <Card title={props.title}>
+          <div>
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                props.onLogin(accessCode);
+              }}
+            >
+              <div className="form-group">
+                <label htmlFor="txtAccessCode">Access Code</label>
+                <input
+                  type="text"
+                  id="txtAccessCode"
+                  className="form-control"
+                  onChange={event => setAccessCode(event.target.value)}
+                />
+              </div>
+              <button className="button button-primary" type="submit">
+                Login
+              </button>
+              <br />
+              <br />
+              {props.error}
+            </form>
+          </div>
+        </Card>
       </div>
-    );
-  }
+    </div>
+  );
 }
-
-export default Login;

--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -9,8 +9,6 @@ import "components/Card.css";
 import "SliderOption.css";
 import { sortByTableNumber } from "helpers.js";
 
-import JudgingTimes from "./JudgingTime";
-
 class SearchandFilter extends Component {
   constructor(props) {
     super(props);

--- a/expo/src/SmallerParentheses.js
+++ b/expo/src/SmallerParentheses.js
@@ -1,16 +1,12 @@
-import React, { Component, Fragment } from "react";
+import React, { Fragment } from "react";
 
-export class SmallerParentheses extends Component {
-  render() {
-    let reducedFontSize = { fontSize: this.props.font_size };
-    return (
-      <Fragment>
-        <span style={reducedFontSize}>(</span>
-        {this.props.children}
-        <span style={reducedFontSize}>)</span>
-      </Fragment>
-    );
-  }
+export default function SmallerParentheses(props) {
+  let reducedFontSize = { fontSize: props.font_size };
+  return (
+    <Fragment>
+      <span style={reducedFontSize}>(</span>
+      {props.children}
+      <span style={reducedFontSize}>)</span>
+    </Fragment>
+  );
 }
-
-export default SmallerParentheses;

--- a/expo/src/Sponsor.js
+++ b/expo/src/Sponsor.js
@@ -28,72 +28,71 @@ library.add(faExclamationTriangle);
 library.add(faClipboardList);
 library.add(faCircle, faCircleSolid);
 
-class WinnersSubmmitedModal extends Component {
-  render() {
-    return (
-      <div
-        class="modal fade bd-example-modal-sm"
-        id="winnersSubmmitedModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="mySmallModalLabel"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog modal-sm modal-dialog-centered">
-          <div class="modal-content" style={{ border: "0px solid" }}>
-            <div class="modal-header" style={{ border: "0px solid" }}>
-              <button
-                type="button"
-                class="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div
-              class="modal-body"
-              style={{
-                color: "white",
-                textAlign: "center",
-                marginTop: "-40px"
-              }}
+// TODO: Replace with `components/GenericConfirmationModal`?
+function WinnersSubmmitedModal() {
+  return (
+    <div
+      class="modal fade bd-example-modal-sm"
+      id="winnersSubmmitedModal"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="mySmallModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content" style={{ border: "0px solid" }}>
+          <div class="modal-header" style={{ border: "0px solid" }}>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
             >
-              <svg
-                class="checkmark"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 52 52"
-              >
-                <circle
-                  class="checkmark__circle"
-                  cx="26"
-                  cy="26"
-                  r="25"
-                  fill="none"
-                />
-                <path
-                  class="checkmark__check"
-                  fill="none"
-                  d="M14.1 27.2l7.1 7.2 16.7-16.8"
-                />
-              </svg>
-              <h3 style={{ padding: "0px 10px" }}>
-                Thanks for submitting your winners!
-              </h3>
-            </div>
-            <div
-              class="modal-footer"
-              style={{ border: "0px solid", paddingTop: "0px" }}
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div
+            class="modal-body"
+            style={{
+              color: "white",
+              textAlign: "center",
+              marginTop: "-40px"
+            }}
+          >
+            <svg
+              class="checkmark"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 52 52"
             >
-              <button className="button button-primary" data-dismiss="modal">
-                OK
-              </button>
-            </div>
+              <circle
+                class="checkmark__circle"
+                cx="26"
+                cy="26"
+                r="25"
+                fill="none"
+              />
+              <path
+                class="checkmark__check"
+                fill="none"
+                d="M14.1 27.2l7.1 7.2 16.7-16.8"
+              />
+            </svg>
+            <h3 style={{ padding: "0px 10px" }}>
+              Thanks for submitting your winners!
+            </h3>
+          </div>
+          <div
+            class="modal-footer"
+            style={{ border: "0px solid", paddingTop: "0px" }}
+          >
+            <button className="button button-primary" data-dismiss="modal">
+              OK
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export class SubmitModal extends Component {
@@ -239,44 +238,42 @@ export class SubmitModal extends Component {
   }
 }
 
-class Task extends Component {
-  render() {
-    let winners = [];
-    if (this.props.winners.length > 0) {
-      this.props.winners.forEach(project_id => {
-        winners.push(<li>{this.props.project_hash[project_id]}</li>);
-      });
-    }
-    let circle = this.props.submitted ? faCheck : faClipboardList;
-
-    return (
-      <Fragment>
-        <div className="btn-group task" role="group">
-          <button className="task-icon">
-            <FontAwesomeIcon icon={circle} className="fa-circle" />
-          </button>
-          {this.props.submitted ? (
-            <button className="task-title">{this.props.challenge}</button>
-          ) : (
-            <button className="task-title">
-              Select your winner{this.props.winners > 1 ? "s" : ""} for{" "}
-              {this.props.challenge}
-            </button>
-          )}
-        </div>
-        {winners.length > 0 ? (
-          <ul
-            className="selection-list"
-            style={{ marginLeft: "50px", marginBottom: "0px" }}
-          >
-            {winners}
-          </ul>
-        ) : (
-          <Fragment></Fragment>
-        )}
-      </Fragment>
-    );
+function Task(props) {
+  let winners = [];
+  if (props.winners.length > 0) {
+    props.winners.forEach(project_id => {
+      winners.push(<li>{props.project_hash[project_id]}</li>);
+    });
   }
+  let circle = props.submitted ? faCheck : faClipboardList;
+
+  return (
+    <Fragment>
+      <div className="btn-group task" role="group">
+        <button className="task-icon">
+          <FontAwesomeIcon icon={circle} className="fa-circle" />
+        </button>
+        {props.submitted ? (
+          <button className="task-title">{props.challenge}</button>
+        ) : (
+          <button className="task-title">
+            Select your winner{props.winners > 1 ? "s" : ""} for{" "}
+            {props.challenge}
+          </button>
+        )}
+      </div>
+      {winners.length > 0 ? (
+        <ul
+          className="selection-list"
+          style={{ marginLeft: "50px", marginBottom: "0px" }}
+        >
+          {winners}
+        </ul>
+      ) : (
+        <Fragment></Fragment>
+      )}
+    </Fragment>
+  );
 }
 
 /* this.props.voting_data =

--- a/expo/src/SponsorLogin.js
+++ b/expo/src/SponsorLogin.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import axiosRequest from "Backend.js";
 
 import Error from "Error.js";
@@ -15,61 +15,37 @@ const errorText =
   "code or are having trouble logging in.";
 const InvalidErr = <Error text={errorText} />;
 
-/* Sponsor login page content (see PRD) */
-class SponsorLogin extends Component {
-  constructor() {
-    super();
-    this.state = {
-      loggedIn: false,
-      error: ""
-    };
-    this.onLogin = this.onLogin.bind(this);
-  }
+export default function SponsorLogin(props) {
+  const [error, setError] = useState("");
 
-  onLogin(accessCode) {
-    let codeExists = accessCode !== undefined && accessCode !== "";
+  const onLogin = accessCode => {
+    const codeExists = accessCode !== undefined && accessCode !== "";
 
     if (codeExists) {
       axiosRequest
         .post("api/login/sponsor", { access_code: accessCode })
         .then(data => {
           if (data.includes("Logged in")) {
-            this.setState({
-              loggedIn: true,
-              error: ""
-            });
-            this.props.history.push({
+            setError("");
+
+            props.history.push({
               pathname: "/sponsor"
             });
           } else {
-            this.setState({
-              loggedIn: false,
-              error: InvalidErr
-            });
+            setError(InvalidErr);
           }
         })
         .catch(error => {
           console.log(error);
         });
     } else {
-      this.setState({
-        loggedIn: false,
-        error: InvalidErr
-      });
+      setError(InvalidErr);
     }
-  }
+  };
 
-  render() {
-    return SiteWrapper(
-      <div className="SponsorLogin">
-        <Login
-          title="Sponsor Login"
-          onLogin={this.onLogin}
-          error={this.state.error}
-        />
-      </div>
-    );
-  }
+  return SiteWrapper(
+    <div className="SponsorLogin">
+      <Login title="Sponsor Login" onLogin={onLogin} error={error} />
+    </div>
+  );
 }
-
-export default SponsorLogin;

--- a/expo/src/Table.js
+++ b/expo/src/Table.js
@@ -18,358 +18,340 @@ import customize from "customize/customize";
 library.add(faCheckSquare);
 library.add(faSquare);
 
-class DiversifyWinnersModal extends Component {
-  render() {
-    return (
-      <div
-        class="modal fade bd-example-modal-sm"
-        id="diversifyWinnersModal"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="mySmallModalLabel"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog modal-sm modal-dialog-centered">
-          <div class="modal-content" style={{ border: "0px solid" }}>
-            <div class="modal-header" style={{ border: "0px solid" }}>
-              <button
-                type="button"
-                class="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div
-              class="modal-body"
-              style={{ color: "white", textAlign: "center" }}
+function DiversifyWinnersModal() {
+  return (
+    <div
+      class="modal fade bd-example-modal-sm"
+      id="diversifyWinnersModal"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="mySmallModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content" style={{ border: "0px solid" }}>
+          <div class="modal-header" style={{ border: "0px solid" }}>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
             >
-              <FontAwesomeIcon
-                icon={faExclamationCircle}
-                size="5x"
-                className="warning"
-              />
-              <div className="diversity-modal">
-                Our current numbers indicate that this project will win 2 +
-                prizes this weekend. We recommend considering alternative
-                projects to allow for more diversity in winners.
-              </div>
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div
+            class="modal-body"
+            style={{ color: "white", textAlign: "center" }}
+          >
+            <FontAwesomeIcon
+              icon={faExclamationCircle}
+              size="5x"
+              className="warning"
+            />
+            <div className="diversity-modal">
+              Our current numbers indicate that this project will win 2 + prizes
+              this weekend. We recommend considering alternative projects to
+              allow for more diversity in winners.
             </div>
-            <div
-              class="modal-footer"
-              style={{ border: "0px solid", paddingTop: "0px" }}
-            >
-              <button className="button button-primary" data-dismiss="modal">
-                OK
-              </button>
-            </div>
+          </div>
+          <div
+            class="modal-footer"
+            style={{ border: "0px solid", paddingTop: "0px" }}
+          >
+            <button className="button button-primary" data-dismiss="modal">
+              OK
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
-export class CheckBoxColumn extends Component {
-  render() {
-    let checkbox = this.props.checked ? faCheckSquare : faSquare;
-    let input = this.props.checked ? (
-      this.props.disabled ? (
-        <input
-          type="checkbox"
-          className="voting-checkbox"
-          value={this.props.project_id}
-          checked
-          disabled
-        />
-      ) : (
-        <input
-          type="checkbox"
-          className="voting-checkbox"
-          value={this.props.project_id}
-          checked
-        />
-      )
-    ) : this.props.disabled ? (
+export function CheckBoxColumn(props) {
+  let checkbox = props.checked ? faCheckSquare : faSquare;
+  let input = props.checked ? (
+    props.disabled ? (
       <input
         type="checkbox"
         className="voting-checkbox"
-        value={this.props.project_id}
+        value={props.project_id}
+        checked
         disabled
       />
     ) : (
       <input
         type="checkbox"
         className="voting-checkbox"
-        value={this.props.project_id}
+        value={props.project_id}
+        checked
       />
-    );
-    let checkboxStyle = this.props.checked
-      ? this.props.disabled
-        ? "fa-check-square disabled"
-        : "fa-check-square"
-      : this.props.disabled
-      ? "fa-square"
-      : "fa-square hoverable";
-    let CustomCheckbox = this.props.disabled ? (
-      <FontAwesomeIcon icon={checkbox} className={checkboxStyle} />
-    ) : (
-      <FontAwesomeIcon
-        icon={checkbox}
-        className={checkboxStyle}
-        onClick={this.props.vote_handler.bind(this, this.props.project_id)}
-      />
-    );
-    return (
-      <td>
-        {!this.props.checked &&
-        this.props.num_challenges_won >= 2 &&
-        !this.props.disabled ? (
-          <label data-toggle="modal" data-target="#diversifyWinnersModal">
-            {CustomCheckbox}
-          </label>
-        ) : (
-          <label>{CustomCheckbox}</label>
-        )}
-        {input}
-        {!this.props.checked && this.props.num_challenges_won >= 2 ? (
-          <DiversifyWinnersModal />
-        ) : (
-          <Fragment></Fragment>
-        )}
-      </td>
-    );
-  }
-}
-
-class ProjectColumn extends Component {
-  render() {
-    let attempted_challenges = this.props.attempted_challenges;
-    let challenges_won = this.props.challenges_won;
-    let colors = customize.table_color;
-    let index = this.props.counter % colors.length;
-    return (
-      <td>
-        <div className="Project header-font">
-          <a href={this.props.project_url} target="_tab" className="link">
-            {this.props.project_name}
-          </a>
-          {this.props.width < 460 ? (
-            this.props.table_number !== "" ? (
-              this.props.origin === "home" ? (
-                <div>
-                  <button
-                    className="Table"
-                    style={{ backgroundColor: colors[index] }}
-                  >
-                    <div className="Table header-font">Table</div>
-                    <div className="Table-Number header-font">
-                      {this.props.table_number}
-                    </div>
-                  </button>
-                </div>
-              ) : (
-                <div className="Sponsor-Table">
-                  Table: {this.props.table_number}
-                </div>
-              )
-            ) : (
-              <Fragment></Fragment>
-            )
-          ) : (
-            <Fragment></Fragment>
-          )}
-          {this.props.width < 460 &&
-          this.props.num_challenges_won > 0 &&
-          this.props.origin === "sponsor" ? (
-            <div className="Sponsor-Table">
-              <img
-                src={WinnerBadge}
-                alt="Winner Badge"
-                style={{ height: "20px", marginRight: "5px" }}
-              />
-              Challenges Won: {this.props.num_challenges_won}
-            </div>
-          ) : (
-            <Fragment></Fragment>
-          )}
-        </div>
-        {this.props.origin === "home" ? (
-          <Fragment>
-            {challenges_won.length > 0 ? (
-              <div className="challenges-won">{challenges_won}</div>
-            ) : (
-              <Fragment></Fragment>
-            )}
-            {attempted_challenges.length > 0 ? (
-              <Fragment>
-                {this.props.width < 460 &&
-                !this.props.show_attempted_challenges ? (
-                  <hr className="attempted-challenges" />
-                ) : null}
-                <div className="attempted-challenges">
-                  {this.props.show_attempted_challenges ? (
-                    <b>
-                      Attempted Challenge
-                      <SmallerParentheses font_size="12px">
-                        s
-                      </SmallerParentheses>
-                      : {attempted_challenges.length}
-                    </b>
-                  ) : (
-                    attempted_challenges
-                  )}
-                </div>
-              </Fragment>
-            ) : (
-              <Fragment></Fragment>
-            )}
-          </Fragment>
-        ) : (
-          <Fragment></Fragment>
-        )}
-      </td>
-    );
-  }
-}
-
-class ChallengeCard extends Component {
-  render() {
-    let text =
-      this.props.width >= 460 ? (
-        " | " + this.props.company
+    )
+  ) : props.disabled ? (
+    <input
+      type="checkbox"
+      className="voting-checkbox"
+      value={props.project_id}
+      disabled
+    />
+  ) : (
+    <input
+      type="checkbox"
+      className="voting-checkbox"
+      value={props.project_id}
+    />
+  );
+  let checkboxStyle = props.checked
+    ? props.disabled
+      ? "fa-check-square disabled"
+      : "fa-check-square"
+    : props.disabled
+    ? "fa-square"
+    : "fa-square hoverable";
+  let CustomCheckbox = props.disabled ? (
+    <FontAwesomeIcon icon={checkbox} className={checkboxStyle} />
+  ) : (
+    <FontAwesomeIcon
+      icon={checkbox}
+      className={checkboxStyle}
+      onClick={this.props.vote_handler.bind(this, props.project_id)}
+    />
+  );
+  return (
+    <td>
+      {!props.checked && props.num_challenges_won >= 2 && !props.disabled ? (
+        <label data-toggle="modal" data-target="#diversifyWinnersModal">
+          {CustomCheckbox}
+        </label>
       ) : (
-        <Fragment>
-          <br />
-          {this.props.company}
-        </Fragment>
-      );
-    return this.props.won && this.props.winnersRevealed ? (
-      this.props.width >= 460 ? (
-        <div className="btn-group">
-          <button className="btn" disabled>
-            <img src={WinnerBadge} alt="Winner Badge" className="Ribbon" />
-          </button>
-          <button className="btn btn-block" disabled>
-            <b>{this.props.challenge_name}</b>
-            {text}
-          </button>
-        </div>
-      ) : (
-        <div>
-          <b>{this.props.challenge_name}</b>
-          {text} <img src={WinnerBadge} alt="Winner Badge" className="Ribbon" />
-        </div>
-      )
-    ) : (
-      <div>
-        <button className="btn btn-block" disabled>
-          <b>{this.props.challenge_name}</b>
-          {text}
-        </button>
-      </div>
-    );
-  }
-}
-
-export class Row extends Component {
-  render() {
-    let attempted_challenges = [];
-    let challenges_won = [];
-    let winner_count = 0;
-    if (this.props.challenges !== undefined) {
-      this.props.challenges.forEach(challenge => {
-        let challenge_card = (
-          <ChallengeCard
-            company={challenge.company}
-            challenge_name={challenge.challenge_name}
-            won={challenge.won}
-            width={this.props.width}
-            winnersRevealed={this.props.winnersRevealed}
-          />
-        );
-        if (challenge.won) {
-          if (this.props.winnersRevealed) {
-            challenges_won.push(challenge_card);
-          } else {
-            attempted_challenges.push(challenge_card);
-          }
-          winner_count += 1;
-        } else {
-          attempted_challenges.push(challenge_card);
-        }
-      });
-    }
-    let table =
-      this.props.width >= 460 ? (
-        <td className="Table-Number header-font">
-          {this.props.table_number === "" ? "-" : this.props.table_number}
-        </td>
+        <label>{CustomCheckbox}</label>
+      )}
+      {input}
+      {!props.checked && props.num_challenges_won >= 2 ? (
+        <DiversifyWinnersModal />
       ) : (
         <Fragment></Fragment>
-      );
-    return (
-      <tr className="voting-row">
-        {this.props.origin === "sponsor" ? (
-          <CheckBoxColumn
-            vote_handler={this.props.vote_handler}
-            project_id={this.props.project_id}
-            checked={this.props.checked}
-            disabled={this.props.disabled}
-            num_challenges_won={winner_count}
-          />
-        ) : (
-          <Fragment></Fragment>
-        )}
-        {table}
-        <ProjectColumn
-          project_name={this.props.project_name}
-          project_url={this.props.project_url}
-          challenges={
-            this.props.origin === "home" ? this.props.challenges : undefined
-          }
-          table_number={this.props.table_number}
-          width={this.props.width}
-          origin={this.props.origin}
-          counter={this.props.counter}
-          show_attempted_challenges={this.props.show_attempted_challenges}
-          attempted_challenges={attempted_challenges}
-          challenges_won={challenges_won}
-          num_challenges_won={winner_count}
-        />
-        {this.props.origin === "sponsor" ? (
-          this.props.width >= 460 ? (
-            <td
-              className="Trophy-Case"
-              style={{
-                fontSize: "35px",
-                fontWeight: "bold",
-                textAlign: "center"
-              }}
-            >
-              {winner_count > 0 ? (
-                <Fragment>
-                  <img
-                    src={WinnerBadge}
-                    alt="Winner Badge"
-                    style={{ height: "40px", marginRight: "10px" }}
-                  />
-                  {winner_count}
-                </Fragment>
-              ) : (
-                <Fragment></Fragment>
-              )}
-            </td>
+      )}
+    </td>
+  );
+}
+
+function ProjectColumn(props) {
+  let attempted_challenges = props.attempted_challenges;
+  let challenges_won = props.challenges_won;
+  let colors = customize.table_color;
+  let index = props.counter % colors.length;
+  return (
+    <td>
+      <div className="Project header-font">
+        <a href={props.project_url} target="_tab" className="link">
+          {props.project_name}
+        </a>
+        {props.width < 460 ? (
+          props.table_number !== "" ? (
+            props.origin === "home" ? (
+              <div>
+                <button
+                  className="Table"
+                  style={{ backgroundColor: colors[index] }}
+                >
+                  <div className="Table header-font">Table</div>
+                  <div className="Table-Number header-font">
+                    {this.props.table_number}
+                  </div>
+                </button>
+              </div>
+            ) : (
+              <div className="Sponsor-Table">Table: {props.table_number}</div>
+            )
           ) : (
             <Fragment></Fragment>
           )
         ) : (
           <Fragment></Fragment>
         )}
-      </tr>
+        {props.width < 460 &&
+        props.num_challenges_won > 0 &&
+        props.origin === "sponsor" ? (
+          <div className="Sponsor-Table">
+            <img
+              src={WinnerBadge}
+              alt="Winner Badge"
+              style={{ height: "20px", marginRight: "5px" }}
+            />
+            Challenges Won: {props.num_challenges_won}
+          </div>
+        ) : (
+          <Fragment></Fragment>
+        )}
+      </div>
+      {props.origin === "home" ? (
+        <Fragment>
+          {challenges_won.length > 0 ? (
+            <div className="challenges-won">{challenges_won}</div>
+          ) : (
+            <Fragment></Fragment>
+          )}
+          {attempted_challenges.length > 0 ? (
+            <Fragment>
+              {props.width < 460 && !props.show_attempted_challenges ? (
+                <hr className="attempted-challenges" />
+              ) : null}
+              <div className="attempted-challenges">
+                {this.props.show_attempted_challenges ? (
+                  <b>
+                    Attempted Challenge
+                    <SmallerParentheses font_size="12px">
+                      s
+                    </SmallerParentheses>: {attempted_challenges.length}
+                  </b>
+                ) : (
+                  attempted_challenges
+                )}
+              </div>
+            </Fragment>
+          ) : (
+            <Fragment></Fragment>
+          )}
+        </Fragment>
+      ) : (
+        <Fragment></Fragment>
+      )}
+    </td>
+  );
+}
+
+function ChallengeCard(props) {
+  let text =
+    props.width >= 460 ? (
+      " | " + props.company
+    ) : (
+      <Fragment>
+        <br />
+        {props.company}
+      </Fragment>
     );
+  return props.won && props.winnersRevealed ? (
+    props.width >= 460 ? (
+      <div className="btn-group">
+        <button className="btn" disabled>
+          <img src={WinnerBadge} alt="Winner Badge" className="Ribbon" />
+        </button>
+        <button className="btn btn-block" disabled>
+          <b>{props.challenge_name}</b>
+          {text}
+        </button>
+      </div>
+    ) : (
+      <div>
+        <b>{props.challenge_name}</b>
+        {text} <img src={WinnerBadge} alt="Winner Badge" className="Ribbon" />
+      </div>
+    )
+  ) : (
+    <div>
+      <button className="btn btn-block" disabled>
+        <b>{props.challenge_name}</b>
+        {text}
+      </button>
+    </div>
+  );
+}
+
+export function Row(props) {
+  let attempted_challenges = [];
+  let challenges_won = [];
+  let winner_count = 0;
+  if (props.challenges !== undefined) {
+    props.challenges.forEach(challenge => {
+      let challenge_card = (
+        <ChallengeCard
+          company={challenge.company}
+          challenge_name={challenge.challenge_name}
+          won={challenge.won}
+          width={props.width}
+          winnersRevealed={props.winnersRevealed}
+        />
+      );
+      if (challenge.won) {
+        if (props.winnersRevealed) {
+          challenges_won.push(challenge_card);
+        } else {
+          attempted_challenges.push(challenge_card);
+        }
+        winner_count += 1;
+      } else {
+        attempted_challenges.push(challenge_card);
+      }
+    });
   }
+  let table =
+    props.width >= 460 ? (
+      <td className="Table-Number header-font">
+        {props.table_number === "" ? "-" : props.table_number}
+      </td>
+    ) : (
+      <Fragment></Fragment>
+    );
+  return (
+    <tr className="voting-row">
+      {props.origin === "sponsor" ? (
+        <CheckBoxColumn
+          vote_handler={props.vote_handler}
+          project_id={props.project_id}
+          checked={props.checked}
+          disabled={props.disabled}
+          num_challenges_won={winner_count}
+        />
+      ) : (
+        <Fragment></Fragment>
+      )}
+      {table}
+      <ProjectColumn
+        project_name={props.project_name}
+        project_url={props.project_url}
+        challenges={props.origin === "home" ? props.challenges : undefined}
+        table_number={props.table_number}
+        width={props.width}
+        origin={props.origin}
+        counter={props.counter}
+        show_attempted_challenges={props.show_attempted_challenges}
+        attempted_challenges={attempted_challenges}
+        challenges_won={challenges_won}
+        num_challenges_won={winner_count}
+      />
+      {props.origin === "sponsor" ? (
+        props.width >= 460 ? (
+          <td
+            className="Trophy-Case"
+            style={{
+              fontSize: "35px",
+              fontWeight: "bold",
+              textAlign: "center"
+            }}
+          >
+            {winner_count > 0 ? (
+              <Fragment>
+                <img
+                  src={WinnerBadge}
+                  alt="Winner Badge"
+                  style={{ height: "40px", marginRight: "10px" }}
+                />
+                {winner_count}
+              </Fragment>
+            ) : (
+              <Fragment></Fragment>
+            )}
+          </td>
+        ) : (
+          <Fragment></Fragment>
+        )
+      ) : (
+        <Fragment></Fragment>
+      )}
+    </tr>
+  );
 }
 
 export class Table extends Component {

--- a/expo/src/admin/ConfirmationButton.js
+++ b/expo/src/admin/ConfirmationButton.js
@@ -1,31 +1,24 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "App.css";
 
-class ConfirmationButton extends Component {
-  render() {
-    return (
-      <div className="p-a-m">
-        <p className="warning-text">
-          Are you sure you want to delete {this.props.elementToDelete}?
-        </p>
-        <div className="float-right">
-          <button
-            className="button button-secondary m-r-s"
-            onClick={this.props.toggleConfirmation}
-          >
-            No
-          </button>
-          <button
-            className="button button-primary"
-            onClick={this.props.deleteElement}
-          >
-            Yes
-          </button>
-        </div>
+export default function ConfirmationButton(props) {
+  return (
+    <div className="p-a-m">
+      <p className="warning-text">
+        Are you sure you want to delete {props.elementToDelete}?
+      </p>
+      <div className="float-right">
+        <button
+          className="button button-secondary m-r-s"
+          onClick={props.toggleConfirmation}
+        >
+          No
+        </button>
+        <button className="button button-primary" onClick={props.deleteElement}>
+          Yes
+        </button>
       </div>
-    );
-  }
+    </div>
+  );
 }
-
-export default ConfirmationButton;

--- a/expo/src/admin/WarningModal.js
+++ b/expo/src/admin/WarningModal.js
@@ -1,54 +1,48 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "App.css";
 
-class WarningModal extends Component {
-  render() {
-    return (
-      <div className="modal fade" id={this.props.modalId} role="dialog">
-        <div className="modal-dialog" role="document">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h5 className="modal-title">
-                Delete All {this.props.whatToDelete}?
-              </h5>
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div className="modal-body">
-              <p className="modal_warning_text">
-                Are you sure you want to delete all{" "}
-                {this.props.whatToDelete.toLowerCase()}?
-              </p>
-            </div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="button button-secondary no"
-                data-dismiss="modal"
-              >
-                No
-              </button>
-              <button
-                type="button"
-                className="button button-primary yes"
-                data-dismiss="modal"
-                onClick={this.props.deleteAll}
-              >
-                Yes
-              </button>
-            </div>
+export default function WarningModal(props) {
+  return (
+    <div className="modal fade" id={props.modalId} role="dialog">
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">Delete All {props.whatToDelete}?</h5>
+            <button
+              type="button"
+              className="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div className="modal-body">
+            <p className="modal_warning_text">
+              Are you sure you want to delete all{" "}
+              {props.whatToDelete.toLowerCase()}?
+            </p>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="button button-secondary no"
+              data-dismiss="modal"
+            >
+              No
+            </button>
+            <button
+              type="button"
+              className="button button-primary yes"
+              data-dismiss="modal"
+              onClick={props.deleteAll}
+            >
+              Yes
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
-
-export default WarningModal;

--- a/expo/src/components/Card.js
+++ b/expo/src/components/Card.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "bootstrap/dist/css/bootstrap.min.css";
 import "components/Card.css";
@@ -6,31 +6,29 @@ import "components/Card.css";
 /**
  * @props
  * title - Title that goes in card header
+ * action
+ * actionName
  */
-class Card extends Component {
-  render() {
-    return (
-      <div class="card">
-        <div className="card-header">
-          <div className="d-flex">
-            <div>
-              <h4>{this.props.title}</h4>
-            </div>
-            <div className="ml-auto">
-              <button
-                type="button"
-                className="link-button"
-                onClick={this.props.action}
-              >
-                {this.props.actionName}
-              </button>
-            </div>
+export default function Card(props) {
+  return (
+    <div class="card">
+      <div className="card-header">
+        <div className="d-flex">
+          <div>
+            <h4>{props.title}</h4>
+          </div>
+          <div className="ml-auto">
+            <button
+              type="button"
+              className="link-button"
+              onClick={props.action}
+            >
+              {props.actionName}
+            </button>
           </div>
         </div>
-        <div className="card-body">{this.props.children}</div>
       </div>
-    );
-  }
+      <div className="card-body">{props.children}</div>
+    </div>
+  );
 }
-
-export default Card;

--- a/expo/src/components/GenericConfirmationModal.js
+++ b/expo/src/components/GenericConfirmationModal.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "App.css";
 
@@ -9,49 +9,44 @@ import "App.css";
  * bodyText - p to offer any explanations/descriptions/information
  * completeAction - method bound to calling class to be called on confirmation
  */
-export default class GenericConfirmationModal extends Component {
-  constructor(props) {
-    super(props);
-  }
-  render() {
-    return (
-      <div className="modal fade" id={this.props.modalId} role="dialog">
-        <div className="modal-dialog" role="document">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h5 className="modal-title">{this.props.modalTitle}</h5>
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div className="modal-body">
-              <p className="modal-text">{this.props.bodyText}</p>
-            </div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="button button-secondary no"
-                data-dismiss="modal"
-              >
-                No
-              </button>
-              <button
-                type="button"
-                className="button button-primary yes"
-                data-dismiss="modal"
-                onClick={this.props.completeAction}
-              >
-                Yes
-              </button>
-            </div>
+export default function GenericConfirmationModal() {
+  return (
+    <div className="modal fade" id={props.modalId} role="dialog">
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">{props.modalTitle}</h5>
+            <button
+              type="button"
+              className="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div className="modal-body">
+            <p className="modal-text">{props.bodyText}</p>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="button button-secondary no"
+              data-dismiss="modal"
+            >
+              No
+            </button>
+            <button
+              type="button"
+              className="button button-primary yes"
+              data-dismiss="modal"
+              onClick={props.completeAction}
+            >
+              Yes
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/expo/src/components/SubmitInputModal.js
+++ b/expo/src/components/SubmitInputModal.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 
 import "App.css";
 
@@ -14,68 +14,62 @@ import "App.css";
  *                  takes @param inputValue (user inputted text)
  * submitText - what to display on the submit button (e.g. "Submit" or "Import from Devpost")
  */
-export default class SubmitInputModal extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { inputValue: "" };
-  }
-  render() {
-    return (
-      <div className="modal fade" id={this.props.modalId} role="dialog">
-        <div className="modal-dialog" role="document">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h5 className="modal-title">{this.props.modalTitle}</h5>
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
+export default function SubmitInputModal(props) {
+  const [inputValue, setInput] = useState("");
+
+  return (
+    <div className="modal fade" id={props.modalId} role="dialog">
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">{props.modalTitle}</h5>
+            <button
+              type="button"
+              className="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div className="modal-body">
+            {props.bodyText != null ? (
+              <p className="modal-text">{props.bodyText}</p>
+            ) : null}
+            <div className="form-group">
+              <label>
+                {props.inputLabel}
+                {props.isInputRequired ? "*" : null}
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                placeholder={props.inputPlaceholder}
+                onChange={e => setInput(e.target.value)}
+                required={props.isInputRequired || false}
+              />
             </div>
-            <div className="modal-body">
-              {this.props.bodyText != null ? (
-                <p className="modal-text">{this.props.bodyText}</p>
-              ) : null}
-              <div className="form-group">
-                <label>
-                  {this.props.inputLabel}
-                  {this.props.isInputRequired ? "*" : null}
-                </label>
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder={this.props.inputPlaceholder}
-                  onChange={e => this.setState({ inputValue: e.target.value })}
-                  required={this.props.isInputRequired || false}
-                />
-              </div>
-            </div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="button button-secondary"
-                data-dismiss="modal"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="button button-primary"
-                data-dismiss="modal"
-                onClick={() => this.props.completeAction(this.state.inputValue)}
-                disabled={
-                  this.props.isInputRequired && this.state.inputValue === ""
-                }
-              >
-                {this.props.submitText}
-              </button>
-            </div>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="button button-secondary"
+              data-dismiss="modal"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="button button-primary"
+              data-dismiss="modal"
+              onClick={() => props.completeAction(inputValue)}
+              disabled={props.isInputRequired && inputValue === ""}
+            >
+              {props.submitText}
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }


### PR DESCRIPTION
The newer 'hooks' syntax for React opts for components as functions,
rather than as classes. For stateless components, this makes a lot more
sense. For stateful components, there are more considerations, but
generally hooks allow for greater code re-use between components and
events.

This change convers some of the 'low hanging fruit' (i.e., mostly
stateless components) to the new hooks syntax.