### PR TITLE
don't assign tables if virtual

### DIFF
--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -34,10 +34,11 @@ assignments = ["None | "] * (num_tables * spots_per_table)
 
 class Project:
     """Project class to hold certain metadata regarding a given project."""
-    def __init__(self, project_url: str, challenges: List[str]):
+    def __init__(self, project_url: str, challenges: List[str], virtual: bool = False):
         self.project_url = project_url
         self.challenges = challenges
         self.table_number = ""
+        self.virtual = virtual
 
     def __str__(self) -> str:
         return str(self.table_number) + " " + str(self.project_url)
@@ -162,6 +163,7 @@ def parse_csv_internal(reader, not_moving_question=None):
         project_name = row["Submission Title"].strip()
         project_url = row["Submission Url"].strip()
         challenges = format_challenges(row["Desired Prizes"])
+        virtual = row["Virtual"].strip() == 'Yes' # TODO: make sure this matches devpost format
 
         # Skip iteration if current project is not valid
         if project_name == "" and project_url == "":
@@ -177,12 +179,12 @@ def parse_csv_internal(reader, not_moving_question=None):
             needs_to_stay = check_if_needs_to_stay(response)
 
         if needs_to_stay is not None:
-            not_moving[project_name] = Project(project_url, challenges)
+            not_moving[project_name] = Project(project_url, challenges, virtual)
             assignments[table_to_number(needs_to_stay.group(0))] = \
                 project_name + " | "
             not_moving[project_name].table_number = needs_to_stay.group(0)
         else:
-            moving[project_name] = Project(project_url, challenges)
+            moving[project_name] = Project(project_url, challenges, virtual)
 
     return moving, not_moving
 

--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -140,7 +140,7 @@ def delete_projects():
     # print("size of not moving: ", len(not_moving))
 
 
-def parse_csv_internal(reader, not_moving_question=None):
+def parse_csv_internal(reader, not_moving_question=None, virtual_row_name=None):
     """Parses a CSV exported from DevPort and seperates hackers based on if
     their hack needs to be stationary (i.e. can't move from table) or not.
 
@@ -164,8 +164,8 @@ def parse_csv_internal(reader, not_moving_question=None):
         project_url = row["Submission Url"].strip()
         challenges = format_challenges(row["Desired Prizes"])
         
-        if "Virtual" in row or "virtual" in row: 
-            virtual = row["Virtual"].strip() == 'Yes' # TODO: make sure this matches devpost format
+        if virtual_row_name in row: 
+            virtual = row[virtual_row_name].strip() == 'Yes' # TODO: make sure this matches devpost format
         else:
             virtual = False
 

--- a/api/seed_db.py
+++ b/api/seed_db.py
@@ -163,7 +163,11 @@ def parse_csv_internal(reader, not_moving_question=None):
         project_name = row["Submission Title"].strip()
         project_url = row["Submission Url"].strip()
         challenges = format_challenges(row["Desired Prizes"])
-        virtual = row["Virtual"].strip() == 'Yes' # TODO: make sure this matches devpost format
+        
+        if "Virtual" in row or "virtual" in row: 
+            virtual = row["Virtual"].strip() == 'Yes' # TODO: make sure this matches devpost format
+        else:
+            virtual = False
 
         # Skip iteration if current project is not valid
         if project_name == "" and project_url == "":

--- a/api/server.py
+++ b/api/server.py
@@ -88,7 +88,8 @@ def get_all_projects():
             'project_name': p['project_name'],
             'project_url': p['project_url'],
             'challenges': challenges,
-            'challenges_won': challenges_won
+            'challenges_won': challenges_won,
+            'virtual': p['virtual']
         }
         projects_list.append(temp_project)
 
@@ -114,7 +115,8 @@ def get_all_projects_with_winners():
             'project_name': p['project_name'],
             'project_url': p['project_url'],
             'challenges': p['challenges'],
-            'challenges_won': p['challenges_won']
+            'challenges_won': p['challenges_won'],
+            'virtual': p['virtual'],
         }
         projects_list.append(temp_project)
 
@@ -137,7 +139,8 @@ def get_project(project_id):
         'project_name': project_obj['project_name'],
         'project_url': project_obj['project_url'],
         'challenges': project_obj['challenges'],
-        'challenges_won': project_obj['challenges_won']
+        'challenges_won': project_obj['challenges_won'],
+        'virtual': project_obj['virtual'],
     }
 
     return jsonify(temp_project)
@@ -452,11 +455,13 @@ def bulk_add_project():
 def update_project(project_id):
     projects = mongo.db.projects
     logged_message(f'endpoint = /api/projects/id/{project_id}, method = POST, params = {project_id}, type = admin')  # noqa
+    
     updated_project_obj = {
         'table_number': request.json['table_number'],
         'project_name': request.json['project_name'],
         'project_url': request.json['project_url'],
         'challenges': request.json['challenges'],
+        'virtual': request.json['virtual'], 
         # 'challenges_won': []  // Don't update challenges_won array
     }
 

--- a/api/server.py
+++ b/api/server.py
@@ -455,9 +455,10 @@ def bulk_add_project():
 def update_project(project_id):
     projects = mongo.db.projects
     logged_message(f'endpoint = /api/projects/id/{project_id}, method = POST, params = {project_id}, type = admin')  # noqa
-    
+
+    table_number = "" if request.json['virtual'] else request.json['table_number']
     updated_project_obj = {
-        'table_number': request.json['table_number'],
+        'table_number': table_number,
         'project_name': request.json['project_name'],
         'project_url': request.json['project_url'],
         'challenges': request.json['challenges'],

--- a/api/server.py
+++ b/api/server.py
@@ -284,7 +284,8 @@ def get_project_list(projects_obj):
             'project_name': project_name,
             'project_url': projects_obj[project_name].project_url,
             'challenges': projects_obj[project_name].challenges,
-            'challenges_won': []
+            'challenges_won': [],
+            'virtual': projects_obj[project_name].virtual,
         }
         project_data.append(info)
     return project_data
@@ -323,7 +324,7 @@ def assign_remaining_table_numbers():
     db_update_operations = []
     for p in all_projects:
         # If table number hasn't been assigned yet, assign next available one
-        if p['table_number'] == '' and i < len(available_tables_list):
+        if not p['virtual'] and p['table_number'] == '' and i < len(available_tables_list):
             db_update_operations.append(UpdateOne(
                 {'_id': ObjectId(p['_id'])},
                 {'$set': {'table_number': available_tables_list[i]}}

--- a/api/server.py
+++ b/api/server.py
@@ -270,7 +270,8 @@ def parse_csv():
                                         encoding="utf8",
                                         errors='ignore'))
 
-        moving, not_moving = parse_csv_internal(reader, current_app.config['CUSTOM_DEVPOST_STAY_AT_TABLE_QUESTION'])  # noqa
+        moving, not_moving = parse_csv_internal(reader, current_app.config['CUSTOM_DEVPOST_STAY_AT_TABLE_QUESTION'], 
+                                                current_app.config['VIRTUAL_ROW_NAME'])  # noqa
 
         bulk_add_projects_internal(get_project_list(not_moving))
         bulk_add_projects_internal(get_project_list(moving))

--- a/expo/src/Table.js
+++ b/expo/src/Table.js
@@ -12,6 +12,7 @@ import "Table.css";
 import "customize/customize";
 import { faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faCheckSquare } from "@fortawesome/free-solid-svg-icons";
+import { faVideo } from "@fortawesome/free-solid-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import customize from "customize/customize";
@@ -230,6 +231,15 @@ export function Row(props) {
   let attempted_challenges = [];
   let challenges_won = [];
   let winner_count = 0;
+
+  let { table_number} = props;
+  if (props.virtual) {
+    table_number = <FontAwesomeIcon className="table-number-icon" icon={faVideo} />
+  } else if (props.table_number === "") {
+    table_number = "-";
+    
+  }
+  
   if (props.challenges !== undefined) {
     props.challenges.forEach((challenge) => {
       let challenge_card = (
@@ -256,7 +266,7 @@ export function Row(props) {
   let table =
     props.width >= 460 ? (
       <td className="Table-Number header-font">
-        {props.table_number === "" ? "-" : props.table_number}
+        {table_number}
       </td>
     ) : null;
   return (
@@ -337,6 +347,7 @@ export function Table(props) {
           width={width}
           challenges={project.challenges}
           winnersRevealed={props.winnersRevealed}
+          virtual={project.virtual}
         />
       ) : (
         <Row
@@ -350,6 +361,7 @@ export function Table(props) {
           counter={counter}
           show_attempted_challenges={props.show_attempted_challenges}
           winnersRevealed={props.winnersRevealed}
+          virtual={project.virtual}
         />
       )
     );

--- a/expo/src/admin/AdminProject.js
+++ b/expo/src/admin/AdminProject.js
@@ -85,6 +85,7 @@ class ProjectModule extends Component {
         url: obj.project_url,
         challenges: challenge,
         company_challenge: obj.challenges,
+        virtual: obj.virtual,
       });
     });
     return finalProjectsData;
@@ -265,6 +266,7 @@ class ProjectModule extends Component {
           allChallenges={allChallenges}
           company_map={challengesToCompanyMap}
           onEdit={this.props.loadProjects}
+          virtual={elt.virtual}
         />
       );
     }
@@ -422,7 +424,7 @@ class ProjectModule extends Component {
               Remove All Table Assignments
             </button>
             {this.state.tableAssignmentStatus !== "" && (
-              <div className="row col" style={{ "padding-top": "1rem" }}>
+              <div className="row col" style={{ "paddingTop": "1rem" }}>
                 <i>{this.state.tableAssignmentStatus}</i>
               </div>
             )}
@@ -488,7 +490,7 @@ class ProjectModule extends Component {
                 id={`project-${elt.project_id}`}
               >
                 <div className="col grow-5 break-word">{elt.project_name}</div>
-                <div className="col">{elt.table_number}</div>
+                <div className="col">{elt.virtual ? ('virtual'):(elt.table_number)}</div>
                 <div className="col">
                   <button
                     className="link-button"

--- a/expo/src/admin/EditProjectModal.js
+++ b/expo/src/admin/EditProjectModal.js
@@ -25,6 +25,7 @@ class EditProjectModal extends Component {
       company_map: this.props.company_map,
       editable: true,
       showConfirmation: false,
+      virtual: this.props.virtual,
     };
   }
 
@@ -50,7 +51,7 @@ class EditProjectModal extends Component {
     let checks = document.querySelector(".black");
     let missing =
       this.state.project_name === "" ||
-      this.state.table_number === "" ||
+      // this.state.table_number === "" ||
       this.state.project_url === "";
     // Note: removed requirement to have at least one checked challenge
     // for (let i = 0; i < this.state.challenges.length; i++) {
@@ -72,6 +73,7 @@ class EditProjectModal extends Component {
           project_url: this.state.project_url,
           table_number: this.state.table_number,
           challenges: challenges,
+          virtual: this.state.virtual,
         })
         .then(this.props.onEdit);
       if (checks) {
@@ -169,6 +171,19 @@ class EditProjectModal extends Component {
                 onChange={(event) =>
                   this.setState({
                     project_url: event.target.value,
+                  })
+                }
+              />
+            </div>
+            <div className="form-group">
+              <label> Virtual Hacker? </label>
+              <input
+                className="form-control"
+                type="checkbox"
+                checked={this.state.virtual}
+                onChange={(event) =>
+                  this.setState({
+                    virtual: !this.state.virtual
                   })
                 }
               />

--- a/expo/src/helpers.js
+++ b/expo/src/helpers.js
@@ -10,6 +10,13 @@ export function sortByTableNumber(array, sortWithAlphaNumeric) {
   if (sortWithAlphaNumeric) {
     // Sort based on alpha portion first, and then numeric as tie-breaker
     return array.sort(function (a, b) {
+      // empty string sorts to the end
+      if (b[key].toString() === '') {
+        return -1;
+      } else if (a[key].toString() === '') {
+        return 1;
+      }
+
       const x = a[key].toString().toLowerCase().split(/([0-9]+)/);
       const y = b[key].toString().toLowerCase().split(/([0-9]+)/);
       const xLetter = x[0];


### PR DESCRIPTION
Closes #64 
- added a `virtual` instance variable to the `Projects` class in `seed_db.py`
- modified `parse_csv_internal` in `seed_db.py` to check the "Virtual" column in the CSV and assign `virtual` var accordingly (**TODO: update this part to match Devpost formatting**) 
- modified table assignment function in `server.py` to skip projects that are marked virtual 
- modified `sortByTableNumber` in `helpers.js` so that projects that are not assigned table numbers are sorted to the end 

To test, I modified one of the CSVs in `data`. Specifically, I added a "Virtual" column at the end and populated it with "Yes" or "No" for each project (since I don't know the Devpost format for the question, I just made it up so that I could test the rest). This is an example screenshot, where the project Swype was marked as virtual:

![Screen Shot 2023-03-28 at 5 11 37 PM](https://user-images.githubusercontent.com/73036278/228367969-18e313c7-b5d1-4f72-8cd9-d3cce472d609.png)
