### PR TITLE
Sumit/challenge filter show times

### DIFF
--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -87,34 +87,36 @@ class SearchandFilterInner extends Component {
   }
 
   applyFilters() {
-    console.log('APPLY FILTER');
-    console.log('this.state.data: ', this.state.data);
-
     // flags for whether to perform filters
     const mustMatchTextFilter = ![undefined, ''].includes(this.state.textSearch);
     const mustMatchChallengeFilter = ![undefined, '', 'All Challenges'].includes(this.state.value);
 
-    console.log('mustMatchTextFilter: ', mustMatchTextFilter);
-    console.log('mustMatchChallengeFilter: ', mustMatchChallengeFilter)
-
-    console.log(this.state.data.map(item => item.challenges));
-    console.log(this.state.data.map(item => item.challenges.map(c => c.challenge_name)));
-    console.log(this.state.value);
-    console.log(this.state.data.map(item => item.challenges.some(c => c.challenge_name === this.state.value)));
-
     // perform filtering
-    const updatedList = this.state.data.filter(item => (
+    let updatedList = this.state.data.filter(item => (
       (!mustMatchTextFilter || item.project_name.toUpperCase().includes(this.state.textSearch.toUpperCase())) &&
       (!mustMatchChallengeFilter || item.challenges.some(c => c.challenge_name === this.state.value))
     ));
 
-    // item.challenges.map(c => c.challenge_name === this.state.value)
+    // sort/display times if filtering by challenge
+    if (mustMatchChallengeFilter) {
+      updatedList.sort((pa, pb) => {
+        // find challenge entries in projects
+        const ca = pa.challenges.find(c => c.challenge_name == this.state.value);
+        const cb = pb.challenges.find(c => c.challenge_name == this.state.value);
 
-    // if challenge filter is selected, filter by time
-    // if (![undefined, '', 'All Challenges'].includes(this.state.value)) {
-    //   console.log('FILTER BY TIME');
-    //   console.log(updatedList)
-    // }
+        // get times for projects
+        const ta = ca.time ? new Date(ca.time) : null;
+        const tb = cb.time ? new Date(cb.time) : null;
+
+        // perform comparison
+        if (ta === null && tb === null) return 0;
+        else if (ta === null) return 1;
+        else if (tb === null) return -1;
+        else if (ta < tb) return -1;
+        else if (tb < ta) return 1;
+        else return 0;
+      })
+    }
 
     this.setState({
       workingdata: updatedList,

--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -87,31 +87,35 @@ class SearchandFilterInner extends Component {
   }
 
   applyFilters() {
-    let updatedList = this.state.data;
-    updatedList = updatedList.filter((item) => {
-      // Check text filter
-      let matchesTextFilter =
-        this.state.textSearch === undefined ||
-        this.state.textSearch === "" ||
-        item.project_name
-          .toUpperCase()
-          .includes(this.state.textSearch.toUpperCase());
+    console.log('APPLY FILTER');
+    console.log('this.state.data: ', this.state.data);
 
-      // Check challenge filter
-      let matchesChallengeFilter =
-        this.state.value === undefined ||
-        this.state.value === "" ||
-        this.state.value === "All Challenges" ||
-        item.challenges.reduce((acc, chal) => {
-          if (chal.challenge_name === this.state.value) {
-            return true;
-          } else {
-            return acc;
-          }
-        }, false);
+    // flags for whether to perform filters
+    const mustMatchTextFilter = ![undefined, ''].includes(this.state.textSearch);
+    const mustMatchChallengeFilter = ![undefined, '', 'All Challenges'].includes(this.state.value);
 
-      return matchesTextFilter && matchesChallengeFilter;
-    });
+    console.log('mustMatchTextFilter: ', mustMatchTextFilter);
+    console.log('mustMatchChallengeFilter: ', mustMatchChallengeFilter)
+
+    console.log(this.state.data.map(item => item.challenges));
+    console.log(this.state.data.map(item => item.challenges.map(c => c.challenge_name)));
+    console.log(this.state.value);
+    console.log(this.state.data.map(item => item.challenges.some(c => c.challenge_name === this.state.value)));
+
+    // perform filtering
+    const updatedList = this.state.data.filter(item => (
+      (!mustMatchTextFilter || item.project_name.toUpperCase().includes(this.state.textSearch.toUpperCase())) &&
+      (!mustMatchChallengeFilter || item.challenges.some(c => c.challenge_name === this.state.value))
+    ));
+
+    // item.challenges.map(c => c.challenge_name === this.state.value)
+
+    // if challenge filter is selected, filter by time
+    // if (![undefined, '', 'All Challenges'].includes(this.state.value)) {
+    //   console.log('FILTER BY TIME');
+    //   console.log(updatedList)
+    // }
+
     this.setState({
       workingdata: updatedList,
     });

--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -87,6 +87,8 @@ class SearchandFilterInner extends Component {
   }
 
   applyFilters() {
+    console.log('this.state.data: ', this.state.data);
+
     // flags for whether to perform filters
     const mustMatchTextFilter = ![undefined, ''].includes(this.state.textSearch);
     const mustMatchChallengeFilter = ![undefined, '', 'All Challenges'].includes(this.state.value);
@@ -97,12 +99,13 @@ class SearchandFilterInner extends Component {
       (!mustMatchChallengeFilter || item.challenges.some(c => c.challenge_name === this.state.value))
     ));
 
-    // sort/display times if filtering by challenge
+    // if filtering by challenge ...
     if (mustMatchChallengeFilter) {
+      // sort by time for that challenge
       updatedList.sort((pa, pb) => {
         // find challenge entries in projects
-        const ca = pa.challenges.find(c => c.challenge_name == this.state.value);
-        const cb = pb.challenges.find(c => c.challenge_name == this.state.value);
+        const ca = pa.challenges.find(c => c.challenge_name === this.state.value);
+        const cb = pb.challenges.find(c => c.challenge_name === this.state.value);
 
         // get times for projects
         const ta = ca.time ? new Date(ca.time) : null;
@@ -115,7 +118,13 @@ class SearchandFilterInner extends Component {
         else if (ta < tb) return -1;
         else if (tb < ta) return 1;
         else return 0;
-      })
+      });
+
+      // dont display other challenges
+      updatedList = updatedList.map(item => ({
+        ...item,
+        challenges: item.challenges.filter(c => c.challenge_name === this.state.value)
+      }));
     }
 
     this.setState({


### PR DESCRIPTION
When filtering by challenges, shows only the time associated with that challenge, and sorts projects by that time.

This is a basic implementation; only looks reasonable when 'Show Attempted Challenges' is on. When it is off, the wrong number of challenges attempted is shown for each project. Potential solutions: (1) enforce that 'Show Attempted Challenges' is true when filtering by challenge, or (2) perform the filtering logic in the table itself.